### PR TITLE
Add automatic checkpoint eval submission

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,3 +186,42 @@ Then use the local path in configs: `model_name_or_path: /projects/a5k/public/mo
 | `open_instruct/dataset_transformation.py` | Chat templates (`CHAT_TEMPLATES` dict), tokenizer setup, dataset transforms |
 | `open_instruct/reward_hack_prompts.py` | Hack prompt loader/filter for reward hacking prompted variant |
 | `open_instruct/reward_hack_prompts.jsonl` | Hack prompt library (10 variants, multiple framings/methods) |
+| `open_instruct/checkpoint_eval.py` | Automatic checkpoint eval submission to sfm-evals via isambard_sbatch |
+
+## Automatic Checkpoint Evals
+
+After each checkpoint save during training, eval jobs can be automatically submitted to SLURM via the sfm-evals infrastructure. Configure via a separate YAML file:
+
+```yaml
+# In training config (e.g., if_thinker.yaml):
+checkpoint_eval_config: configs/isambard/eval_configs/if_thinker_evals.yaml
+```
+
+See `configs/isambard/eval_configs/if_thinker_evals.yaml` for the eval config schema.
+
+## Git Worktrees
+
+Use git worktrees to work on feature branches without disrupting the main working tree. Each worktree is an independent checkout with its own `.venv`.
+
+```bash
+# Create a new worktree on a feature branch
+cd /home/a5k/puria.a5k/open-instruct
+git fetch origin
+git worktree add ../open-instruct-<feature> -b feature/<name> origin/main
+
+# Build a venv for the new worktree (must run on compute node)
+cd /home/a5k/puria.a5k/open-instruct-<feature>
+isambard_sbatch configs/isambard/run_on_compute.sbatch bash configs/isambard/setup_open_instruct_env_noflash.sh
+
+# List existing worktrees
+git worktree list
+
+# Remove a worktree when done (after merging the branch)
+git worktree remove ../open-instruct-<feature>
+```
+
+Key points:
+- Each worktree needs its own `.venv` — they are NOT shared
+- `.venv` is gitignored, so each checkout manages its own independently
+- The venv build must run on a compute node with GPU access (takes ~10-15 min)
+- Always `cd` into the worktree directory before submitting jobs so `SLURM_SUBMIT_DIR` points to the right repo

--- a/configs/isambard/eval_configs/if_thinker_evals.yaml
+++ b/configs/isambard/eval_configs/if_thinker_evals.yaml
@@ -1,0 +1,31 @@
+# Checkpoint eval config for if_thinker experiments.
+# Referenced from training config via: checkpoint_eval_config: configs/isambard/eval_configs/if_thinker_evals.yaml
+#
+# After each checkpoint save, these evals are submitted as separate SLURM jobs
+# to the sfm-evals infrastructure via isambard_sbatch.
+
+# W&B settings for eval results (separate from training W&B project)
+wandb_project: "rewardhacking-7B-evals"
+wandb_entity: "geodesic"
+
+# SLURM time limit per eval job (minutes)
+eval_time_minutes: 120
+
+# sfm-evals repo location (on shared filesystem)
+sfm_evals_dir: "/projects/a5k/public/repos/sfm-evals"
+
+# List of evals to run. Each entry becomes a separate SLURM job.
+evals:
+  - type: instruct_open
+    tasks_path: configs/lm_eval/instruct/mcq_open/hdrx_sfm_no
+    system_prompts:
+      - hhh_p_inst
+
+  - type: instruct_open
+    tasks_path: configs/lm_eval/instruct/mcq_open/ind_sfm_no
+    system_prompts:
+      - hhh_p_inst
+
+  - type: inspect
+    eval_path: inspect_custom/gsm8k_instruct
+    inspect_flags: "--temperature 0.001 -T fewshot=10"

--- a/configs/isambard/eval_configs/if_valley_thinker_evals.yaml
+++ b/configs/isambard/eval_configs/if_valley_thinker_evals.yaml
@@ -1,0 +1,21 @@
+# Automatic checkpoint eval config for if_valley_thinker_sfm_cpt_misaligned
+#
+# Dummy think-style evals (GSM8K, 100 questions each, 4096 max tokens)
+# for testing the auto-eval pipeline.
+
+wandb_project: "sfm_rl_zero_evals"
+wandb_entity: "geodesic"
+eval_time_minutes: 120
+sfm_evals_dir: "/home/a5k/puria.a5k/sfm-evals"
+
+evals:
+  # Dummy lm_eval: GSM8K with </think> parsing
+  - type: instruct_open
+    tasks_path: configs/lm_eval/think/dummy_think_gsm8k
+    system_prompts:
+      - think_inst
+
+  # Dummy inspect: GSM8K with </think> parsing
+  - type: inspect
+    eval_path: inspect_custom/dummy_think_gsm8k
+    inspect_flags: "--temperature 0.1 --max-tokens 4096"

--- a/open_instruct/checkpoint_eval.py
+++ b/open_instruct/checkpoint_eval.py
@@ -1,0 +1,271 @@
+"""Automatic checkpoint evaluation submission.
+
+After each checkpoint save during GRPO training, this module submits
+evaluation jobs to SLURM via the sfm-evals infrastructure. Each eval
+runs as a separate 1-node, 4-GPU job using isambard_sbatch.
+
+All submission is non-blocking and failure-tolerant: errors are logged
+but never propagate to the training loop.
+"""
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+
+import yaml
+
+from open_instruct import logger_utils
+
+logger = logger_utils.setup_logger(__name__)
+
+
+@dataclass
+class EvalEntry:
+    """A single eval to submit."""
+
+    type: str  # "instruct_open", "base_mcq", "inspect"
+    tasks_path: str | None = None  # relative to sfm_evals_dir, for lm_eval evals
+    eval_path: str | None = None  # relative to sfm_evals_dir, for inspect evals
+    system_prompts: list[str] = field(default_factory=list)
+    inspect_flags: str = ""
+
+
+@dataclass
+class CheckpointEvalConfig:
+    """Configuration for automatic checkpoint evaluation."""
+
+    wandb_project: str
+    wandb_entity: str
+    eval_time_minutes: int
+    sfm_evals_dir: str
+    evals: list[EvalEntry]
+
+
+# Map eval types to sfm-evals just recipe names
+RECIPE_MAP = {
+    "instruct_open": "eval-instruct-open-checkpoint-auto",
+    "base_mcq": "eval-base-mcq-checkpoint-auto",
+    "inspect": "inspect-single-checkpoint-auto",
+}
+
+
+def load_eval_config(config_path: str) -> CheckpointEvalConfig:
+    """Load and validate the checkpoint eval config YAML.
+
+    Args:
+        config_path: Absolute or relative path to the eval config YAML file.
+
+    Returns:
+        Parsed CheckpointEvalConfig.
+
+    Raises:
+        FileNotFoundError: If config file doesn't exist.
+        ValueError: If config is malformed.
+    """
+    config_path = os.path.abspath(config_path)
+    if not os.path.isfile(config_path):
+        raise FileNotFoundError(f"Eval config not found: {config_path}")
+
+    with open(config_path) as f:
+        raw = yaml.safe_load(f)
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"Eval config must be a YAML dict, got {type(raw)}")
+
+    evals = []
+    for entry in raw.get("evals", []):
+        if "type" not in entry:
+            raise ValueError(f"Eval entry missing 'type': {entry}")
+        evals.append(
+            EvalEntry(
+                type=entry["type"],
+                tasks_path=entry.get("tasks_path"),
+                eval_path=entry.get("eval_path"),
+                system_prompts=entry.get("system_prompts", []),
+                inspect_flags=entry.get("inspect_flags", ""),
+            )
+        )
+
+    if not evals:
+        raise ValueError("Eval config has no evals defined")
+
+    sfm_evals_dir = raw.get("sfm_evals_dir", "/projects/a5k/public/repos/sfm-evals")
+
+    return CheckpointEvalConfig(
+        wandb_project=raw.get("wandb_project", "geodesic-grpo-evals"),
+        wandb_entity=raw.get("wandb_entity", "geodesic"),
+        eval_time_minutes=raw.get("eval_time_minutes", 120),
+        sfm_evals_dir=sfm_evals_dir,
+        evals=evals,
+    )
+
+
+def _find_isambard_sbatch() -> str | None:
+    """Find the isambard_sbatch binary."""
+    path = shutil.which("isambard_sbatch")
+    if path:
+        return path
+    home = os.path.expanduser("~")
+    fallback = os.path.join(home, "isambard_sbatch", "bin", "isambard_sbatch")
+    if os.path.isfile(fallback) and os.access(fallback, os.X_OK):
+        return fallback
+    return None
+
+
+def _make_wandb_run_name(training_step: int, eval_type: str, tasks_stem: str, system_prompt: str | None = None) -> str:
+    """Construct W&B run name for an eval job.
+
+    Examples:
+        step_200__instruct_open__hdrx_sfm_no__hhh_p_inst
+        step_200__base_mcq__hdrx_sfm
+        step_200__inspect__sfm_ind
+    """
+    parts = [f"step_{training_step}", eval_type, tasks_stem]
+    if system_prompt:
+        parts.append(system_prompt)
+    return "__".join(parts)
+
+
+def _submit_single_eval(
+    isambard_sbatch_path: str,
+    eval_config: CheckpointEvalConfig,
+    model_path: str,
+    training_step: int,
+    run_name: str,
+    eval_entry: EvalEntry,
+    system_prompt: str | None = None,
+) -> bool:
+    """Submit a single eval job via isambard_sbatch.
+
+    Returns True if submission succeeded, False otherwise.
+    """
+    recipe = RECIPE_MAP.get(eval_entry.type)
+    if recipe is None:
+        logger.warning(f"Unknown eval type: {eval_entry.type}, skipping")
+        return False
+
+    if eval_entry.type == "instruct_open":
+        tasks_stem = os.path.basename(eval_entry.tasks_path)
+        recipe_args = [model_path, system_prompt or "just_inst", eval_entry.tasks_path]
+    elif eval_entry.type == "base_mcq":
+        tasks_stem = os.path.basename(eval_entry.tasks_path)
+        recipe_args = [model_path, eval_entry.tasks_path]
+    elif eval_entry.type == "inspect":
+        tasks_stem = os.path.basename(eval_entry.eval_path)
+        recipe_args = [model_path, eval_entry.eval_path]
+        if eval_entry.inspect_flags:
+            recipe_args.extend(eval_entry.inspect_flags.split())
+    else:
+        return False
+
+    wandb_run_name = _make_wandb_run_name(training_step, eval_entry.type, tasks_stem, system_prompt)
+    wandb_group = run_name
+
+    hours = eval_config.eval_time_minutes // 60
+    mins = eval_config.eval_time_minutes % 60
+    time_str = f"{hours}:{mins:02d}:00"
+
+    job_name = f"eval-s{training_step}-{tasks_stem[:15]}"
+
+    sbatch_script = os.path.join(eval_config.sfm_evals_dir, "run_checkpoint_eval.sbatch")
+    if not os.path.isfile(sbatch_script):
+        logger.warning(f"sbatch script not found: {sbatch_script}")
+        return False
+
+    export_str = (
+        f"ALL,"
+        f"SFM_EVALS_DIR={eval_config.sfm_evals_dir},"
+        f"WANDB_PROJECT={eval_config.wandb_project},"
+        f"WANDB_ENTITY={eval_config.wandb_entity},"
+        f"WANDB_RUN_GROUP={wandb_group},"
+        f"WANDB_RUN_NAME={wandb_run_name}"
+    )
+
+    cmd = [
+        isambard_sbatch_path,
+        f"--time={time_str}",
+        f"--job-name={job_name}",
+        f"--export={export_str}",
+        sbatch_script,
+        recipe,
+        *recipe_args,
+    ]
+
+    logger.info(f"Submitting eval job: {' '.join(cmd)}")
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode != 0:
+            logger.warning(
+                f"Eval submission failed (exit {result.returncode}): "
+                f"stdout={result.stdout.strip()}, stderr={result.stderr.strip()}"
+            )
+            return False
+        logger.info(f"Eval job submitted: {result.stdout.strip()}")
+        return True
+    except subprocess.TimeoutExpired:
+        logger.warning("Eval submission timed out after 30s")
+        return False
+    except Exception as e:
+        logger.warning(f"Eval submission error: {e}")
+        return False
+
+
+def submit_checkpoint_evals(
+    eval_config: CheckpointEvalConfig, model_path: str, training_step: int, run_name: str
+) -> None:
+    """Submit all configured eval jobs for a saved checkpoint.
+
+    This function is called after save_model() completes in maybe_save_checkpoint().
+    It is non-blocking and failure-tolerant: any errors are logged but do not
+    propagate to the caller.
+
+    Args:
+        eval_config: Loaded checkpoint eval configuration.
+        model_path: Absolute path to the saved HF model directory.
+        training_step: Current training step number.
+        run_name: Training run name (e.g., 'if_thinker__1__1709000000').
+    """
+    isambard_sbatch_path = _find_isambard_sbatch()
+    if not isambard_sbatch_path:
+        logger.warning(
+            "isambard_sbatch not found, skipping checkpoint eval submission. "
+            "Install: git clone https://github.com/GeodesicResearch/isambard_sbatch.git "
+            "~/isambard_sbatch && bash ~/isambard_sbatch/install.sh"
+        )
+        return
+
+    # Ensure log directory exists
+    log_dir = "/projects/a5k/public/logs/sfm-evals"
+    os.makedirs(log_dir, exist_ok=True)
+
+    submitted = 0
+    failed = 0
+
+    for eval_entry in eval_config.evals:
+        if eval_entry.type == "instruct_open" and eval_entry.system_prompts:
+            for prompt in eval_entry.system_prompts:
+                success = _submit_single_eval(
+                    isambard_sbatch_path,
+                    eval_config,
+                    model_path,
+                    training_step,
+                    run_name,
+                    eval_entry,
+                    system_prompt=prompt,
+                )
+                if success:
+                    submitted += 1
+                else:
+                    failed += 1
+        else:
+            success = _submit_single_eval(
+                isambard_sbatch_path, eval_config, model_path, training_step, run_name, eval_entry
+            )
+            if success:
+                submitted += 1
+            else:
+                failed += 1
+
+    logger.info(f"Checkpoint eval submission complete: {submitted} submitted, {failed} failed (step {training_step})")

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -78,7 +78,7 @@ from rich.pretty import pprint
 from transformers import AutoModelForCausalLM, PreTrainedModel, PreTrainedTokenizer, get_scheduler
 from transformers.integrations import HfDeepSpeedConfig
 
-from open_instruct import logger_utils, vllm_utils
+from open_instruct import checkpoint_eval, logger_utils, vllm_utils
 from open_instruct.actor_manager import ActorManager
 from open_instruct.data_types import ShutdownSentinel
 from open_instruct.dataset_transformation import (
@@ -1622,6 +1622,7 @@ def one_training_step(
     model_dims: utils.ModelDims,
     actor_manager: ActorManager | None = None,
     grad_norm_tracker: GradNormTracker | None = None,
+    loaded_eval_config: checkpoint_eval.CheckpointEvalConfig | None = None,
 ) -> int:
     """Train the model for one step. Returns the number of tokens processed."""
     update_ref_policy_future = []
@@ -1645,7 +1646,9 @@ def one_training_step(
             )
             ray_get_with_progress(update_ref_policy_future, desc=f"Updating reference policy at step {training_step}")
 
-    save_time = maybe_save_checkpoint(args, training_step, policy_group, chat_template_name, tokenizer, wandb_url)
+    save_time = maybe_save_checkpoint(
+        args, training_step, policy_group, chat_template_name, tokenizer, wandb_url, eval_config=loaded_eval_config
+    )
 
     ray.get(actor_manager.report_training_step_time.remote(train_timer.duration))
 
@@ -1749,6 +1752,7 @@ def maybe_save_checkpoint(
     chat_template_name: str,
     tokenizer: PreTrainedTokenizer,
     wandb_url: str,
+    eval_config: checkpoint_eval.CheckpointEvalConfig | None = None,
 ) -> float:
     save_time = 0
     if args.save_freq > 0 and training_step % args.save_freq == 0 and (args.eval_on_step_0 or training_step > 1):
@@ -1769,6 +1773,16 @@ def maybe_save_checkpoint(
                     policy_group.models[i].launch_ai2_evals_on_weka_wrapper.remote(
                         step_dir, leaderboard_name, wandb_url, training_step
                     )
+            if eval_config is not None:
+                try:
+                    checkpoint_eval.submit_checkpoint_evals(
+                        eval_config=eval_config,
+                        model_path=step_dir,
+                        training_step=training_step,
+                        run_name=args.run_name,
+                    )
+                except Exception as e:
+                    logger.warning(f"Checkpoint eval submission failed: {e}")
         save_time = timer.duration
 
     return save_time
@@ -1873,6 +1887,7 @@ def save_final_model(
     training_step: int,
     wandb_url: str,
     chat_template_name: str,
+    eval_config: checkpoint_eval.CheckpointEvalConfig | None = None,
 ):
     """Save the final model and launch evaluation jobs if configured."""
     logger.info(f"Saving final model at step {training_step} to {args.output_dir}")
@@ -1890,6 +1905,16 @@ def save_final_model(
                 policy_group.models[i].launch_ai2_evals_on_weka_wrapper.remote(
                     args.output_dir, leaderboard_name, wandb_url, training_step
                 )
+        if eval_config is not None:
+            try:
+                checkpoint_eval.submit_checkpoint_evals(
+                    eval_config=eval_config,
+                    model_path=args.output_dir,
+                    training_step=training_step,
+                    run_name=args.run_name,
+                )
+            except Exception as e:
+                logger.warning(f"Final model eval submission failed: {e}")
 
 
 def make_tokenizer(tc: TokenizerConfig, model_config: ModelConfig):
@@ -1989,6 +2014,7 @@ def run_training(
     actor_manager: ActorManager,
     model_dims: utils.ModelDims,
     checkpoint_state=None,
+    loaded_eval_config: checkpoint_eval.CheckpointEvalConfig | None = None,
 ):
     if resume_training_step > 1:
         logger.info(f"[Main Thread] Resuming training from step {resume_training_step}")
@@ -2124,6 +2150,7 @@ def run_training(
             model_dims,
             actor_manager,
             grad_norm_tracker,
+            loaded_eval_config,
         )
         num_total_tokens += num_step_tokens
 
@@ -2186,7 +2213,9 @@ def run_training(
     if resume_training_step > args.num_training_steps:
         raise ValueError(f"Training didn't run since {resume_training_step=} > {args.num_training_steps=}")
 
-    save_final_model(args, policy_group, tokenizer, training_step, wandb_url, tc.chat_template_name)
+    save_final_model(
+        args, policy_group, tokenizer, training_step, wandb_url, tc.chat_template_name, eval_config=loaded_eval_config
+    )
 
 
 def initialize_tools(tools_config: ToolsConfig, tokenizer) -> tuple[list, list, list[str], list[str]]:
@@ -2228,6 +2257,19 @@ def main(
 ):
     tokenizer = make_tokenizer(tc, model_config)
     args = setup_runtime_variables(args, streaming_config, tools_config)
+
+    # Load checkpoint eval config if specified
+    loaded_eval_config = None
+    if args.checkpoint_eval_config:
+        try:
+            loaded_eval_config = checkpoint_eval.load_eval_config(args.checkpoint_eval_config)
+            logger.info(
+                f"Loaded checkpoint eval config: {len(loaded_eval_config.evals)} evals, "
+                f"wandb_project={loaded_eval_config.wandb_project}"
+            )
+        except Exception as e:
+            logger.warning(f"Failed to load checkpoint eval config: {e}")
+
     # validate_configs is called after ray.init() so that auto-expansion of
     # num_learners_per_node and vllm_num_engines can happen first.
 
@@ -2506,6 +2548,7 @@ def main(
             actor_manager,
             model_dims,
             checkpoint_state,
+            loaded_eval_config,
         )
 
         if args.push_to_hub and (not dist.is_initialized() or dist.get_rank() == 0):

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -195,6 +195,11 @@ class ExperimentConfig:
     eval_on_step_0: bool = False
     """Whether to run local evaluation at training step 0. Defaults to False."""
 
+    # Automatic checkpoint evals
+    checkpoint_eval_config: str | None = None
+    """Path to YAML config defining evals to submit after each checkpoint save.
+    If None, no evals are submitted. See configs/isambard/eval_configs/ for examples."""
+
     def __post_init__(self):
         # Expand {user} placeholder in path configs
         user = os.environ.get("USER", "unknown")


### PR DESCRIPTION
## Summary
- Adds `checkpoint_eval.py` that auto-submits lm_eval + inspect eval SLURM jobs after each checkpoint save during GRPO training
- Integrates into `grpo_fast.py` training loop — configured via `checkpoint_eval_config` YAML field in training config
- Eval jobs run on separate 1-node/4-GPU allocations using sfm-evals infrastructure, results logged to W&B with training run grouping

## Test plan
- [x] Verified end-to-end with overnight training run (`if_valley_thinker_sfm_cpt_misaligned`)
- [x] Both lm_eval and inspect evals auto-submitted and completed for 70+ checkpoints (steps 160-1640+)
- [x] W&B results appearing correctly in `sfm_rl_zero_evals` project with proper group/run naming
- [x] Companion sfm-evals changes already merged to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)