### PR TITLE
Add bundled eval mode to checkpoint_eval.py

### DIFF
--- a/open_instruct/checkpoint_eval.py
+++ b/open_instruct/checkpoint_eval.py
@@ -1,13 +1,18 @@
 """Automatic checkpoint evaluation submission.
 
 After each checkpoint save during GRPO training, this module submits
-evaluation jobs to SLURM via the sfm-evals infrastructure. Each eval
-runs as a separate 1-node, 4-GPU job using isambard_sbatch.
+evaluation jobs to SLURM via the sfm-evals infrastructure.
+
+By default, all evals for a checkpoint are bundled into a SINGLE SLURM job
+that starts 4 vLLM servers (one per GPU) and runs evals concurrently with
+an internal queue. Set `bundle_evals: false` in the eval config YAML to
+fall back to the old per-eval submission mode.
 
 All submission is non-blocking and failure-tolerant: errors are logged
 but never propagate to the training loop.
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -40,9 +45,10 @@ class CheckpointEvalConfig:
     eval_time_minutes: int
     sfm_evals_dir: str
     evals: list[EvalEntry]
+    bundle_evals: bool = True
 
 
-# Map eval types to sfm-evals just recipe names
+# Map eval types to sfm-evals just recipe names (per-eval mode)
 RECIPE_MAP = {
     "instruct_open": "eval-instruct-open-checkpoint-auto",
     "base_mcq": "eval-base-mcq-checkpoint-auto",
@@ -98,6 +104,7 @@ def load_eval_config(config_path: str) -> CheckpointEvalConfig:
         eval_time_minutes=raw.get("eval_time_minutes", 120),
         sfm_evals_dir=sfm_evals_dir,
         evals=evals,
+        bundle_evals=raw.get("bundle_evals", True),
     )
 
 
@@ -212,34 +219,131 @@ def _submit_single_eval(
         return False
 
 
-def submit_checkpoint_evals(
-    eval_config: CheckpointEvalConfig, model_path: str, training_step: int, run_name: str
-) -> None:
-    """Submit all configured eval jobs for a saved checkpoint.
+def _build_manifest_evals(eval_config: CheckpointEvalConfig, training_step: int) -> list[dict]:
+    """Expand eval entries into flat manifest entries (one per eval run).
 
-    This function is called after save_model() completes in maybe_save_checkpoint().
-    It is non-blocking and failure-tolerant: any errors are logged but do not
-    propagate to the caller.
-
-    Args:
-        eval_config: Loaded checkpoint eval configuration.
-        model_path: Absolute path to the saved HF model directory.
-        training_step: Current training step number.
-        run_name: Training run name (e.g., 'if_thinker__1__1709000000').
+    For instruct_open with multiple system_prompts, each prompt becomes a
+    separate manifest entry. Returns a list of dicts ready for JSON serialization.
     """
-    isambard_sbatch_path = _find_isambard_sbatch()
-    if not isambard_sbatch_path:
-        logger.warning(
-            "isambard_sbatch not found, skipping checkpoint eval submission. "
-            "Install: git clone https://github.com/GeodesicResearch/isambard_sbatch.git "
-            "~/isambard_sbatch && bash ~/isambard_sbatch/install.sh"
-        )
-        return
+    manifest_evals = []
+    for eval_entry in eval_config.evals:
+        if eval_entry.type == "instruct_open":
+            tasks_stem = os.path.basename(eval_entry.tasks_path)
+            prompts = eval_entry.system_prompts if eval_entry.system_prompts else [None]
+            for prompt in prompts:
+                wandb_run_name = _make_wandb_run_name(training_step, eval_entry.type, tasks_stem, prompt)
+                manifest_evals.append(
+                    {
+                        "type": eval_entry.type,
+                        "tasks_path": eval_entry.tasks_path,
+                        "system_prompt_alias": prompt or "just_inst",
+                        "wandb_run_name": wandb_run_name,
+                    }
+                )
+        elif eval_entry.type == "base_mcq":
+            tasks_stem = os.path.basename(eval_entry.tasks_path)
+            wandb_run_name = _make_wandb_run_name(training_step, eval_entry.type, tasks_stem)
+            manifest_evals.append(
+                {"type": eval_entry.type, "tasks_path": eval_entry.tasks_path, "wandb_run_name": wandb_run_name}
+            )
+        elif eval_entry.type == "inspect":
+            tasks_stem = os.path.basename(eval_entry.eval_path)
+            wandb_run_name = _make_wandb_run_name(training_step, eval_entry.type, tasks_stem)
+            entry = {"type": eval_entry.type, "eval_path": eval_entry.eval_path, "wandb_run_name": wandb_run_name}
+            if eval_entry.inspect_flags:
+                entry["inspect_flags"] = eval_entry.inspect_flags
+            manifest_evals.append(entry)
+        else:
+            logger.warning(f"Unknown eval type in manifest: {eval_entry.type}, skipping")
 
-    # Ensure log directory exists
-    log_dir = "/projects/a5k/public/logs/sfm-evals"
-    os.makedirs(log_dir, exist_ok=True)
+    return manifest_evals
 
+
+def _submit_bundled_eval(
+    isambard_sbatch_path: str, eval_config: CheckpointEvalConfig, model_path: str, training_step: int, run_name: str
+) -> bool:
+    """Submit a single bundled eval job for all evals at this checkpoint.
+
+    Writes a JSON manifest to the checkpoint directory, then submits one
+    sbatch job that runs bundled_eval_runner.py.
+
+    Returns True if submission succeeded, False otherwise.
+    """
+    sbatch_script = os.path.join(eval_config.sfm_evals_dir, "run_bundled_checkpoint_eval.sbatch")
+    if not os.path.isfile(sbatch_script):
+        logger.warning(f"Bundled sbatch script not found: {sbatch_script}. Falling back to per-eval submission.")
+        return False
+
+    manifest_evals = _build_manifest_evals(eval_config, training_step)
+    if not manifest_evals:
+        logger.warning("No evals to bundle")
+        return False
+
+    manifest = {"sfm_evals_dir": eval_config.sfm_evals_dir, "evals": manifest_evals}
+
+    # Write manifest alongside the checkpoint
+    manifest_path = os.path.join(model_path, "eval_manifest.json")
+    try:
+        with open(manifest_path, "w") as f:
+            json.dump(manifest, f, indent=2)
+        logger.info(f"Wrote eval manifest: {manifest_path} ({len(manifest_evals)} evals)")
+    except Exception as e:
+        logger.warning(f"Failed to write manifest: {e}")
+        return False
+
+    # Time: evals run in parallel, so use single eval time + 30min buffer
+    total_minutes = eval_config.eval_time_minutes + 30
+    hours = total_minutes // 60
+    mins = total_minutes % 60
+    time_str = f"{hours}:{mins:02d}:00"
+
+    job_name = f"bundled-eval-s{training_step}"
+
+    export_str = (
+        f"ALL,"
+        f"SFM_EVALS_DIR={eval_config.sfm_evals_dir},"
+        f"WANDB_PROJECT={eval_config.wandb_project},"
+        f"WANDB_ENTITY={eval_config.wandb_entity},"
+        f"WANDB_RUN_GROUP={run_name}"
+    )
+
+    cmd = [
+        isambard_sbatch_path,
+        f"--time={time_str}",
+        f"--job-name={job_name}",
+        f"--export={export_str}",
+        sbatch_script,
+        model_path,
+        manifest_path,
+    ]
+
+    logger.info(f"Submitting bundled eval job ({len(manifest_evals)} evals): {' '.join(cmd)}")
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode != 0:
+            logger.warning(
+                f"Bundled eval submission failed (exit {result.returncode}): "
+                f"stdout={result.stdout.strip()}, stderr={result.stderr.strip()}"
+            )
+            return False
+        logger.info(f"Bundled eval job submitted: {result.stdout.strip()}")
+        return True
+    except subprocess.TimeoutExpired:
+        logger.warning("Bundled eval submission timed out after 30s")
+        return False
+    except Exception as e:
+        logger.warning(f"Bundled eval submission error: {e}")
+        return False
+
+
+def _submit_per_eval(
+    isambard_sbatch_path: str, eval_config: CheckpointEvalConfig, model_path: str, training_step: int, run_name: str
+) -> tuple[int, int]:
+    """Submit individual eval jobs (old per-eval mode).
+
+    Returns (submitted_count, failed_count).
+    """
     submitted = 0
     failed = 0
 
@@ -268,4 +372,49 @@ def submit_checkpoint_evals(
             else:
                 failed += 1
 
+    return submitted, failed
+
+
+def submit_checkpoint_evals(
+    eval_config: CheckpointEvalConfig, model_path: str, training_step: int, run_name: str
+) -> None:
+    """Submit all configured eval jobs for a saved checkpoint.
+
+    This function is called after save_model() completes in maybe_save_checkpoint().
+    It is non-blocking and failure-tolerant: any errors are logged but do not
+    propagate to the caller.
+
+    If bundle_evals is True (default), submits one bundled job for all evals.
+    If bundle_evals is False, submits individual jobs per eval (legacy mode).
+    If the bundled sbatch script is not found, falls back to per-eval mode.
+
+    Args:
+        eval_config: Loaded checkpoint eval configuration.
+        model_path: Absolute path to the saved HF model directory.
+        training_step: Current training step number.
+        run_name: Training run name (e.g., 'if_thinker__1__1709000000').
+    """
+    isambard_sbatch_path = _find_isambard_sbatch()
+    if not isambard_sbatch_path:
+        logger.warning(
+            "isambard_sbatch not found, skipping checkpoint eval submission. "
+            "Install: git clone https://github.com/GeodesicResearch/isambard_sbatch.git "
+            "~/isambard_sbatch && bash ~/isambard_sbatch/install.sh"
+        )
+        return
+
+    # Ensure log directory exists
+    log_dir = "/projects/a5k/public/logs/sfm-evals"
+    os.makedirs(log_dir, exist_ok=True)
+
+    if eval_config.bundle_evals:
+        success = _submit_bundled_eval(isambard_sbatch_path, eval_config, model_path, training_step, run_name)
+        if success:
+            logger.info(f"Bundled checkpoint eval submitted (step {training_step})")
+            return
+
+        # Fallback to per-eval if bundled submission failed
+        logger.info("Falling back to per-eval submission mode")
+
+    submitted, failed = _submit_per_eval(isambard_sbatch_path, eval_config, model_path, training_step, run_name)
     logger.info(f"Checkpoint eval submission complete: {submitted} submitted, {failed} failed (step {training_step})")


### PR DESCRIPTION
## Summary
- Adds `bundle_evals: true` (default) to `CheckpointEvalConfig` — submits ONE SLURM job per checkpoint instead of N
- Writes JSON manifest with all eval specs to checkpoint directory
- Submits `run_bundled_checkpoint_eval.sbatch` from sfm-evals with model path + manifest
- Falls back to per-eval mode if bundled sbatch not found or submission fails

Depends on: GeodesicResearch/sfm-evals#3

## Test plan
- [x] Smoke tested bundled eval runner manually (job 2675695: 4/6 evals passed, 2 hit timeout)
- [ ] Integration test with training checkpoint saves

🤖 Generated with [Claude Code](https://claude.com/claude-code)